### PR TITLE
Switch build instances to xenial & python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@
 
 language: python
 sudo: required
-dist: trusty
-python: "3.6.1"
+dist: xenial
+python: "3.7"
 services:
   - docker
 git:


### PR DESCRIPTION
Now using Xenial and Python 3.7 within TravisCI. Sticking to preinstalled Python 3.7.1 for now.
Ref:
- https://docs.travis-ci.com/user/languages/python/
- https://docs.travis-ci.com/user/reference/xenial/#python-support 