### PR TITLE
Use image digests in AppRollouts

### DIFF
--- a/applayer-yaml/dummy-mission-controller/approllout.yaml
+++ b/applayer-yaml/dummy-mission-controller/approllout.yaml
@@ -13,9 +13,7 @@ spec:
   appName: dummy-mission-controller-$APP_VERSION
   cloud: 
     values:
-      image:
-        repository: "ewmcloudrobotics/dummy-mission-controller"
-        tag: "latest"
+      image: "ewmcloudrobotics/dummy-mission-controller:latest"
   ## Select dummy robots only!
   robots:
   - selector:

--- a/applayer-yaml/ewm-monitoring-ui/approllout.yaml
+++ b/applayer-yaml/ewm-monitoring-ui/approllout.yaml
@@ -13,9 +13,7 @@ spec:
   appName: ewm-monitoring-ui-$APP_VERSION
   cloud: 
     values:
-      image:
-        repository: "ewmcloudrobotics/monitoring-ui"
-        image.tag: "latest"
+      image: "ewmcloudrobotics/monitoring-ui:latest"
       envs:
         ewmhost: "" # Host for the OData API endpoint
         ewmbasepath: "/odata/SAP/ZEWM_ROBCO_SRV" # Basepath for the OData API matching the service definition

--- a/applayer-yaml/ewm-order-auction/approllout.yaml
+++ b/applayer-yaml/ewm-order-auction/approllout.yaml
@@ -18,11 +18,7 @@ spec:
       matchLabels:
         model: mir100
     values:
-      image:
-        repository: "ewmcloudrobotics/order-bid-agent"
-        tag: "latest"
+      image: "ewmcloudrobotics/order-bid-agent:latest"
   cloud:
     values:
-      image:
-        repository: "ewmcloudrobotics/order-auctioneer"
-        tag: "latest"
+      image: "ewmcloudrobotics/order-auctioneer:latest"

--- a/applayer-yaml/ewm-order-manager/approllout.yaml
+++ b/applayer-yaml/ewm-order-manager/approllout.yaml
@@ -13,9 +13,7 @@ spec:
   appName: ewm-order-manager-$APP_VERSION
   cloud: 
     values:
-      image:
-        repository: "ewmcloudrobotics/order-manager"
-        tag: "latest"
+      image: "ewmcloudrobotics/order-manager:latest"
       envs:
         ewmhost: "" # Host for the OData API endpoint
         ewmuser: "" # Technical user for all warehouseorder related API calls

--- a/applayer-yaml/ewm-robot-controller-cloud/approllout.yaml
+++ b/applayer-yaml/ewm-robot-controller-cloud/approllout.yaml
@@ -13,9 +13,7 @@ spec:
   appName: ewm-robot-controller-cloud-$APP_VERSION
   cloud: 
     values:
-      image:
-        repository: "ewmcloudrobotics/robot-controller"
-        tag: "latest"
+      image: "ewmcloudrobotics/robot-controller:latest"
       envs:
         maxretrycount: 1 # Maximum number of retries for failed missions
   ## Select only those robot models that require cloud controllers

--- a/applayer-yaml/ewm-robot-controller/approllout.yaml
+++ b/applayer-yaml/ewm-robot-controller/approllout.yaml
@@ -18,16 +18,12 @@ spec:
       matchLabels:
         model: mir100
     values:
-      image:
-        repository: "ewmcloudrobotics/robot-controller"
-        tag: "latest"
+      image: "ewmcloudrobotics/robot-controller:latest"
       envs:
         maxretrycount: 1 # Maximum number of retries for failed missions
   cloud:
     values:
-      image:
-        repository: "ewmcloudrobotics/robot-configurator"
-        tag: "latest"
+      image: "ewmcloudrobotics/robot-configurator:latest"
       envs:
         ewmhost: "" # Host for the OData API endpoint
         ewmuser: "" # Technical user for all warehouseorder related API calls

--- a/applayer-yaml/ewm-sim/approllout.yaml
+++ b/applayer-yaml/ewm-sim/approllout.yaml
@@ -13,9 +13,7 @@ spec:
   appName: ewm-sim-$APP_VERSION
   cloud: 
     values:
-      image:
-        repository: "ewmcloudrobotics/ewm-sim"
-        tag: "latest"
+      image: "ewmcloudrobotics/ewm-sim:latest"
       envs:
         ewmhost: "" # Host for the OData API endpoint
         ewmuser: "" # Technical user for all warehouseorder related API calls

--- a/applayer-yaml/fetch-mission-controller/approllout.yaml
+++ b/applayer-yaml/fetch-mission-controller/approllout.yaml
@@ -13,9 +13,7 @@ spec:
   appName: fetch-mission-controller-$APP_VERSION
   cloud: 
     values:
-      image:
-        repository: "ewmcloudrobotics/fetch-mission-controller"
-        tag: "latest"
+      image: "ewmcloudrobotics/fetch-mission-controller:latest"
       envs:
         clientsecret: "" # Client secret of fetch core instance
         user: "" # User to connect to fetch core

--- a/applayer-yaml/mir-mission-controller/approllout.yaml
+++ b/applayer-yaml/mir-mission-controller/approllout.yaml
@@ -16,9 +16,7 @@ spec:
       matchLabels:
         model: mir100
     values:
-      image:
-        repository: "ewmcloudrobotics/mir-mission-controller"
-        tag: "latest"
+      image: "ewmcloudrobotics/mir-mission-controller:latest"
       envs:
         plctrolley: 0 # PLC register of robot which is set to 1 when a trolley is attached
         miruser: "" # User to connect to MiR API

--- a/applayer-yaml/mir-runtime-estimator/approllout.yaml
+++ b/applayer-yaml/mir-runtime-estimator/approllout.yaml
@@ -16,9 +16,7 @@ spec:
       matchLabels:
         model: mir100
     values:
-      image:
-        repository: "ewmcloudrobotics/mir-runtime-estimator"
-        tag: "latest"
+      image: "ewmcloudrobotics/mir-runtime-estimator:latest"
       envs:
         miruser: "" # User to connect to MiR API
         mirpassword: "" # Password for MiR user

--- a/helm/charts/cloud/dummy-mission-controller/templates/mission-controller.yaml
+++ b/helm/charts/cloud/dummy-mission-controller/templates/mission-controller.yaml
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: dummy-mission-controller-{{ .name }}
 spec:
-  replicas: {{ $.Values.replicaCount }}
+  replicas: 1
   selector:
     matchLabels:
       app: dummy-mission-controller-{{ .name }}
@@ -16,8 +16,7 @@ spec:
     spec:
       containers:
       - name: dummy-mission-controller-{{ .name }}
-        image: {{ $.Values.image.repository }}{{ if $.Values.image.tag }}:{{ $.Values.image.tag }}{{ end }}
-        imagePullPolicy: Always
+        image: {{ .Values.image }}
         env:
         - name: ROBCO_ROBOT_NAME
           value: "{{ .name }}"

--- a/helm/charts/cloud/dummy-mission-controller/values.yaml
+++ b/helm/charts/cloud/dummy-mission-controller/values.yaml
@@ -1,7 +1,4 @@
-replicaCount: 1
-image:
-  repository: "ewmcloudrobotics/dummy-mission-controller"
-  tag: "latest"
+image: "ewmcloudrobotics/dummy-mission-controller:latest"
 
 robot:
   name: ""

--- a/helm/charts/cloud/ewm-monitoring-ui/templates/monitoring-ui.yaml
+++ b/helm/charts/cloud/ewm-monitoring-ui/templates/monitoring-ui.yaml
@@ -57,7 +57,7 @@ kind: Deployment
 metadata:
   name: monitoring-ui
 spec:
-  replicas: {{ .Values.replicaCount }}
+  replicas: 1
   selector:
     matchLabels:
       app: monitoring-ui
@@ -81,8 +81,7 @@ spec:
         image: bitnami/kubectl:latest
         args: ["proxy", "--port=8003", "--accept-paths=^/apis/ewm.sap.com/v1alpha1/namespaces/default/robotconfigurations/*", "--reject-methods='DELETE,POST'"]
       - name: nginx-openui5
-        image: {{ .Values.image.repository }}{{ if .Values.image.tag }}:{{ .Values.image.tag }}{{ end }}
-        imagePullPolicy: Always
+        image: {{ .Values.image }}
         ports:
         - containerPort: 80
         volumeMounts:

--- a/helm/charts/cloud/ewm-monitoring-ui/values.yaml
+++ b/helm/charts/cloud/ewm-monitoring-ui/values.yaml
@@ -1,9 +1,6 @@
 domain: "example.com"
-replicaCount: 1
 
-image:
-  repository: "ewmcloudrobotics/monitoring-ui"
-  tag: "latest"
+image: "ewmcloudrobotics/monitoring-ui:latest"
 
 nginxpath: "/ewm-monitoring-ui"
 

--- a/helm/charts/cloud/ewm-order-auction/templates/order-auction.yaml
+++ b/helm/charts/cloud/ewm-order-auction/templates/order-auction.yaml
@@ -4,7 +4,7 @@ kind: Deployment
 metadata:
   name: order-auctioneer
 spec:
-  replicas: {{ $.Values.replicaCount }}
+  replicas: 1
   selector:
     matchLabels:
       app: order-auctioneer
@@ -14,8 +14,7 @@ spec:
         app: order-auctioneer
     spec:
       containers:
-      - image: {{ $.Values.image.repository }}{{ if $.Values.image.tag }}:{{ $.Values.image.tag }}{{ end }}
-        imagePullPolicy: Always
+      - image: {{ .Values.image }}
         name: order-auctioneer
         env:
         - name: DEPLOYED_ROBOTS

--- a/helm/charts/cloud/ewm-order-auction/values.yaml
+++ b/helm/charts/cloud/ewm-order-auction/values.yaml
@@ -1,8 +1,4 @@
-replicaCount: 1
-
-image:
-  repository: "ewmcloudrobotics/order-auctioneer"
-  tag: "latest"
+image: "ewmcloudrobotics/order-auctioneer:latest"
 
 robots: []
 

--- a/helm/charts/cloud/ewm-order-manager/templates/order-manager.yaml
+++ b/helm/charts/cloud/ewm-order-manager/templates/order-manager.yaml
@@ -20,7 +20,7 @@ kind: Deployment
 metadata:
   name: order-manager
 spec:
-  replicas: {{ .Values.replicaCount }}
+  replicas: 1
   selector:
     matchLabels:
       app: order-manager
@@ -30,8 +30,7 @@ spec:
         app: order-manager
     spec:
       containers:
-      - image: {{ .Values.image.repository }}{{ if .Values.image.tag }}:{{ .Values.image.tag }}{{ end }}
-        imagePullPolicy: Always
+      - image: {{ .Values.image }}
         name: order-manager
         env:
         - name: EWM_USER

--- a/helm/charts/cloud/ewm-order-manager/values.yaml
+++ b/helm/charts/cloud/ewm-order-manager/values.yaml
@@ -1,8 +1,4 @@
-replicaCount: 1
-
-image:
-  repository: "ewmcloudrobotics/order-manager"
-  tag: "latest"
+image: "ewmcloudrobotics/order-manager:latest"
 
 envs:
   ewmuser: ""

--- a/helm/charts/cloud/ewm-robot-controller-cloud/templates/robot-controller.yaml
+++ b/helm/charts/cloud/ewm-robot-controller-cloud/templates/robot-controller.yaml
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: robot-controller-{{ .name }}
 spec:
-  replicas: {{ $.Values.replicaCount }}
+  replicas: 1
   selector:
     matchLabels:
       app: robot-controller-{{ .name }}
@@ -15,8 +15,7 @@ spec:
         app: robot-controller-{{ .name }}
     spec:
       containers:
-      - image: {{ $.Values.image.repository }}{{ if $.Values.image.tag }}:{{ $.Values.image.tag }}{{ end }}
-        imagePullPolicy: Always
+      - image: {{ $.Values.image }}
         name: robot-controller
         env:
         - name: ROBCO_ROBOT_NAME

--- a/helm/charts/cloud/ewm-robot-controller-cloud/values.yaml
+++ b/helm/charts/cloud/ewm-robot-controller-cloud/values.yaml
@@ -1,10 +1,7 @@
-replicaCount: 1
+image: "ewmcloudrobotics/robot-controller:latest"
 
-image:
-  repository: "ewmcloudrobotics/robot-controller"
-  tag: "latest"
-
-robots: []
+robots:
+  - name: "z"
 
 envs:
   maxretrycount: 1

--- a/helm/charts/cloud/ewm-robot-controller/templates/robot-controller.yaml
+++ b/helm/charts/cloud/ewm-robot-controller/templates/robot-controller.yaml
@@ -20,7 +20,7 @@ kind: Deployment
 metadata:
   name: robot-configurator
 spec:
-  replicas: {{ .Values.replicaCount }}
+  replicas: 1
   selector:
     matchLabels:
       app: robot-configurator
@@ -30,8 +30,7 @@ spec:
         app: robot-configurator
     spec:
       containers:
-      - image: {{ .Values.image.repository }}{{ if .Values.image.tag }}:{{ .Values.image.tag }}{{ end }}
-        imagePullPolicy: Always
+      - image: {{ .Values.image }}
         name: robot-configurator
         env:
         - name: EWM_USER

--- a/helm/charts/cloud/ewm-robot-controller/values.yaml
+++ b/helm/charts/cloud/ewm-robot-controller/values.yaml
@@ -1,8 +1,4 @@
-replicaCount: 1
-
-image:
-  repository: "ewmcloudrobotics/robot-configurator"
-  tag: "latest"
+image: "ewmcloudrobotics/robot-configurator:latest"
 
 envs:
   ewmuser: ""

--- a/helm/charts/cloud/ewm-sim/templates/ewm-sim.yaml
+++ b/helm/charts/cloud/ewm-sim/templates/ewm-sim.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: ewm-sim
-        image: {{ .Values.ewmsim.image.repository }}{{ if .Values.ewmsim.image.tag }}:{{ .Values.ewmsim.image.tag }}{{ end }}
+        image: {{ .Values.ewmsim.image }}
         ports:
         - containerPort: 8080
           name: odata-api

--- a/helm/charts/cloud/ewm-sim/values.yaml
+++ b/helm/charts/cloud/ewm-sim/values.yaml
@@ -1,8 +1,5 @@
 ewmsim:
-  replicaCount: 1
-  image:
-    repository: "ewmcloudrobotics/ewm-sim"
-    tag: "latest"
+  image: "ewmcloudrobotics/ewm-sim:latest"
   envs:
     ewm:
       user: "someuser"

--- a/helm/charts/cloud/fetch-mission-controller/templates/mission-controller.yaml
+++ b/helm/charts/cloud/fetch-mission-controller/templates/mission-controller.yaml
@@ -17,7 +17,7 @@ kind: Deployment
 metadata:
   name: fetch-mission-controller
 spec:
-  replicas: {{ .Values.replicaCount }}
+  replicas: 1
   selector:
     matchLabels:
       app: fetch-mission-controller
@@ -28,8 +28,7 @@ spec:
     spec:
       containers:
       - name: fetch-mission-controller
-        image: {{ .Values.image.repository }}{{ if .Values.image.tag }}:{{ .Values.image.tag }}{{ end }}
-        imagePullPolicy: Always
+        image: {{ .Values.image }}
         env:
         - name: FETCHCORE_USER
           valueFrom:

--- a/helm/charts/cloud/fetch-mission-controller/values.yaml
+++ b/helm/charts/cloud/fetch-mission-controller/values.yaml
@@ -1,7 +1,4 @@
-replicaCount: 1
-image:
-  repository: "ewmcloudrobotics/fetch-mission-controller"
-  tag: "latest"
+image: "ewmcloudrobotics/fetch-mission-controller:latest"
 
 envs:
   clientsecret: ""

--- a/helm/charts/robot/ewm-order-auction/templates/order-bid-agent.yaml
+++ b/helm/charts/robot/ewm-order-auction/templates/order-bid-agent.yaml
@@ -4,7 +4,7 @@ kind: Deployment
 metadata:
   name: order-bid-agent-{{ .Values.robot.name }}
 spec:
-  replicas: {{ $.Values.replicaCount }}
+  replicas: 1
   selector:
     matchLabels:
       app: order-bid-agent-{{ .Values.robot.name }}
@@ -14,8 +14,7 @@ spec:
         app: order-bid-agent-{{ .Values.robot.name }}
     spec:
       containers:
-      - image: {{ $.Values.image.repository }}{{ if $.Values.image.tag }}:{{ $.Values.image.tag }}{{ end }}
-        imagePullPolicy: Always
+      - image: {{ .Values.image }}
         name: order-bid-agent
         env:
         - name: ROBCO_ROBOT_NAME

--- a/helm/charts/robot/ewm-order-auction/values.yaml
+++ b/helm/charts/robot/ewm-order-auction/values.yaml
@@ -1,11 +1,7 @@
-replicaCount: 1
-
-image:
-  repository: "ewmcloudrobotics/order-bid-agent"
-  tag: "latest"
+image: "ewmcloudrobotics/order-bid-agent:latest"
 
 robot:
-  name: ""
+  name: "z"
 
 envs:
   zerologconfig: "json"

--- a/helm/charts/robot/ewm-robot-controller/templates/robot-controller.yaml
+++ b/helm/charts/robot/ewm-robot-controller/templates/robot-controller.yaml
@@ -4,7 +4,7 @@ kind: Deployment
 metadata:
   name: robot-controller-{{ .Values.robot.name }}
 spec:
-  replicas: {{ .Values.replicaCount }}
+  replicas: 1
   selector:
     matchLabels:
       app: robot-controller-{{ .Values.robot.name }}
@@ -14,8 +14,7 @@ spec:
         app: robot-controller-{{ .Values.robot.name }}
     spec:
       containers:
-      - image: {{ .Values.image.repository }}{{ if .Values.image.tag }}:{{ .Values.image.tag }}{{ end }}
-        imagePullPolicy: Always
+      - image: {{ .Values.image }}
         name: robot-controller
         env:
         - name: ROBCO_ROBOT_NAME

--- a/helm/charts/robot/ewm-robot-controller/values.yaml
+++ b/helm/charts/robot/ewm-robot-controller/values.yaml
@@ -1,11 +1,7 @@
-replicaCount: 1
-
-image:
-  repository: "ewmcloudrobotics/robot-controller"
-  tag: "latest"
+image: "ewmcloudrobotics/robot-controller:latest"
 
 robot:
-  name: ""
+  name: "z"
 
 envs:
   maxretrycount: 1

--- a/helm/charts/robot/mir-mission-controller/templates/mission-controller.yaml
+++ b/helm/charts/robot/mir-mission-controller/templates/mission-controller.yaml
@@ -15,7 +15,7 @@ kind: Deployment
 metadata:
   name: mir-mission-controller-{{ .Values.robot.name }}
 spec:
-  replicas: {{ .Values.replicaCount }}
+  replicas: 1
   selector:
     matchLabels:
       app: mir-mission-controller-{{ .Values.robot.name }}
@@ -26,8 +26,7 @@ spec:
     spec:
       containers:
       - name: mir-mission-controller
-        image: {{ .Values.image.repository }}{{ if .Values.image.tag }}:{{ .Values.image.tag }}{{ end }}
-        imagePullPolicy: Always
+        image: {{ .Values.image }}
         env:
         - name: MIR_USER
           valueFrom:

--- a/helm/charts/robot/mir-mission-controller/values.yaml
+++ b/helm/charts/robot/mir-mission-controller/values.yaml
@@ -1,7 +1,4 @@
-replicaCount: 1
-image:
-  repository: "ewmcloudrobotics/mir-mission-controller"
-  tag: "latest"
+image: "ewmcloudrobotics/mir-mission-controller:latest"
 
 envs:
   plctrolley: 5
@@ -10,4 +7,4 @@ envs:
   mirhost: "mir-api.default.svc.cluster.local"
 
 robot:
-  name: ""
+  name: "z"

--- a/helm/charts/robot/mir-runtime-estimator/templates/runtime-estimator.yaml
+++ b/helm/charts/robot/mir-runtime-estimator/templates/runtime-estimator.yaml
@@ -15,7 +15,7 @@ kind: Deployment
 metadata:
   name: mir-runtime-estimator-{{ .Values.robot.name }}
 spec:
-  replicas: {{ .Values.replicaCount }}
+  replicas: 1
   selector:
     matchLabels:
       app: mir-runtime-estimator-{{ .Values.robot.name }}
@@ -26,8 +26,7 @@ spec:
     spec:
       containers:
       - name: mir-runtime-estimator
-        image: {{ .Values.image.repository }}{{ if .Values.image.tag }}:{{ .Values.image.tag }}{{ end }}
-        imagePullPolicy: Always
+        image: {{ .Values.image }}
         env:
         - name: MIR_USER
           valueFrom:

--- a/helm/charts/robot/mir-runtime-estimator/values.yaml
+++ b/helm/charts/robot/mir-runtime-estimator/values.yaml
@@ -1,7 +1,4 @@
-replicaCount: 1
-image:
-  repository: "ewmcloudrobotics/mir-runtime-estimator"
-  tag: "latest"
+image: "ewmcloudrobotics/mir-runtime-estimator"
 
 envs:
   miruser: "admin"
@@ -14,4 +11,4 @@ envs:
   zerologloglevel: "info"
 
 robot:
-  name: ""
+  name: "z"


### PR DESCRIPTION
Replace image tags by digests on `./deploy.sh rollout <app>` .
Existing `approllout.yaml` files have to be changed according to the new templates in order to work again.