### PR TITLE
Update .gitignore for ewm-sim v2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -169,3 +169,9 @@ ci/scan-modules/whitesource-fs-agent-configs/*
 # whitelist for ewm-sim logger
 !docker/ewm-sim/lib/
 !docker/ewm-sim/lib/*
+
+# ewm-sim mocha tests and node_modules
+docker/ewm-sim/.nyc_output/
+docker/ewm-sim/.nyc_output/*
+docker/ewm-sim/node_modules/
+docker/ewm-sim/node_modules/*


### PR DESCRIPTION
we do not want to accidentally push node_modules or test coverage output